### PR TITLE
No offset fix

### DIFF
--- a/lib/rfc_3339_date_time_serializer.dart
+++ b/lib/rfc_3339_date_time_serializer.dart
@@ -32,11 +32,6 @@ class RFC3339DateTimeSerializer extends PrimitiveSerializer<DateTime> {
   @override
   Object serialize(Serializers serializers, DateTime dateTime,
       {FullType specifiedType = FullType.unspecified}) {
-    if (!dateTime.isUtc) {
-      throw ArgumentError.value(
-          dateTime, 'dateTime', 'Must be in utc for serialization.');
-    }
-
     return dateTime.toIso8601String();
   }
 

--- a/lib/rfc_3339_date_time_serializer.dart
+++ b/lib/rfc_3339_date_time_serializer.dart
@@ -9,23 +9,24 @@ class RFC3339DateTimeSerializer extends PrimitiveSerializer<DateTime> {
     final serializedString = serialized as String;
 
     final fixed = serializedString.replaceAllMapped(
-      RegExp(r"(.*:\d\d)(\.\d+)?(Z|[+-]\d{2}:\d{2})"),
+      RegExp(r"(.*:\d\d)(\.\d+)(Z|[+-]\d{2}:\d{2})?"),
       (Match match) {
         // #1 capturing group is date and time without a fraction of a second
         // #2 group is `time-secfrac` - if present
         // #3 group is `time-offset`
         String timeSecfrac = match[2] ?? '';
+        String timeOffset = match[3] ?? '';
 
         if (timeSecfrac.length > 7) {
           // 6 is 0th period + (up to) 6 characters accepted by ISO8601
           timeSecfrac = timeSecfrac.substring(0, 7);
         }
 
-        return match[1] + timeSecfrac + match[3];
+        return match[1] + timeSecfrac + timeOffset;
       },
     );
 
-    return DateTime.parse(fixed).toUtc();
+    return DateTime.parse(fixed);
   }
 
   @override

--- a/test/rfc_3339_date_time_serializer_test.dart
+++ b/test/rfc_3339_date_time_serializer_test.dart
@@ -1,6 +1,5 @@
-import 'package:test/test.dart';
-
 import 'package:rfc_3339_date_time_serializer/rfc_3339_date_time_serializer.dart';
+import 'package:test/test.dart';
 
 void main() {
   test('correctly parses RFC 3339 dates', () {
@@ -10,6 +9,7 @@ void main() {
       // ISO 8601
       '2019-08-09T06:55:01.896826+05:00': DateTime.utc(2019, 8, 9, 1, 55, 1, 896, 826),
       '2019-08-09T06:55:01.896826Z': DateTime.utc(2019, 8, 9, 6, 55, 1, 896, 826),
+      '2019-11-19T01:21:11.021105': DateTime(2019, 11, 19, 1, 21, 11, 021, 105),
 
       // RFC 3339
       '2019-05-31T10:35:45.347333481Z': DateTime.utc(2019, 5, 31, 10, 35, 45, 347, 333),


### PR DESCRIPTION
This fixes deserializing dates that have no offset. Because dates can have no offset, UTC cannot be guaranteed so this also removes that restriction.